### PR TITLE
Cleanup et refactor de la logique du jeu de Nim

### DIFF
--- a/src/main/java/fr/nc0/cda/nim/controleur/ControleurJeuNim.java
+++ b/src/main/java/fr/nc0/cda/nim/controleur/ControleurJeuNim.java
@@ -6,17 +6,28 @@
 
 package fr.nc0.cda.nim.controleur;
 
+import fr.nc0.cda.nim.modele.EtatPartieNim;
 import fr.nc0.cda.nim.modele.Joueur;
 import fr.nc0.cda.nim.modele.Nim;
 import fr.nc0.cda.nim.vue.Ihm;
 import java.util.ArrayList;
 
+/** Contrôleur du jeu de Nim. */
 public class ControleurJeuNim {
-
+  /** Interface homme-machine. */
   private final Ihm ihm;
+
+  /** Liste des joueurs de la partie. */
   private final ArrayList<Joueur> lesJoueurs;
+
+  /** Partie en cours du jeu de Nim. */
   private Nim nim;
 
+  /**
+   * Créer un contrôleur de jeu de Nim.
+   *
+   * @param ihm l'interface homme-machine.
+   */
   public ControleurJeuNim(Ihm ihm) {
     this.ihm = ihm;
 
@@ -29,17 +40,18 @@ public class ControleurJeuNim {
       }
     }
 
-    lesJoueurs = new ArrayList<Joueur>(2);
+    lesJoueurs = new ArrayList<>(2);
     lesJoueurs.add(new Joueur(ihm.selectNomJoueur(1)));
     lesJoueurs.add(new Joueur(ihm.selectNomJoueur(2)));
   }
 
+  /** Jouer une partie du jeu de Nim. */
   public void jouer() {
 
     nim.demarrerPartie();
     Joueur currentPlayer = lesJoueurs.get(0);
 
-    while (nim.getEtatPartie() == Nim.EtatPartie.EnCours) {
+    while (nim.getEtatPartie() == EtatPartieNim.EnCours) {
       ihm.afficherEtatPartie(nim.getTas());
       while (true) {
         int[] choix = ihm.selectAlumette(currentPlayer.getNom());
@@ -51,7 +63,7 @@ public class ControleurJeuNim {
         }
       }
       nim.checkEtatPartie();
-      if (nim.getEtatPartie() == Nim.EtatPartie.EnCours) {
+      if (nim.getEtatPartie() == EtatPartieNim.EnCours) {
         currentPlayer = nextPlayer(currentPlayer);
       }
     }
@@ -85,6 +97,12 @@ public class ControleurJeuNim {
     }
   }
 
+  /**
+   * Récupère le joueur suivant.
+   *
+   * @param currentPlayer le joueur actuel.
+   * @return le joueur suivant.
+   */
   private Joueur nextPlayer(Joueur currentPlayer) {
     if (currentPlayer == lesJoueurs.get(0)) {
       return lesJoueurs.get(1);

--- a/src/main/java/fr/nc0/cda/nim/controleur/ControleurJeuNim.java
+++ b/src/main/java/fr/nc0/cda/nim/controleur/ControleurJeuNim.java
@@ -51,7 +51,7 @@ public class ControleurJeuNim {
     nim.demarrerPartie();
     Joueur currentPlayer = lesJoueurs.get(0);
 
-    while (nim.getEtatPartie() == EtatPartieNim.EnCours) {
+    while (nim.getEtatPartie() == EtatPartieNim.EN_COURS) {
       ihm.afficherEtatPartie(nim.getTas());
       while (true) {
         int[] choix = ihm.selectAlumette(currentPlayer.getNom());
@@ -63,7 +63,7 @@ public class ControleurJeuNim {
         }
       }
       nim.checkEtatPartie();
-      if (nim.getEtatPartie() == EtatPartieNim.EnCours) {
+      if (nim.getEtatPartie() == EtatPartieNim.EN_COURS) {
         currentPlayer = nextPlayer(currentPlayer);
       }
     }

--- a/src/main/java/fr/nc0/cda/nim/modele/EtatPartieNim.java
+++ b/src/main/java/fr/nc0/cda/nim/modele/EtatPartieNim.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Lucas Paulo, Younes Ouaammou, Nicolas Paul.
+ * Use of this source code is governed by a BSD-style license
+ * that can be found in the COPYRIGHT file.
+ */
+
+package fr.nc0.cda.nim.modele;
+
+/** Représente l'état d'une partie du jeu de Nim. */
+public enum EtatPartieNim {
+  /** La partie est en cours. */
+  EnCours,
+  /** La partie est finie. */
+  Fini
+}

--- a/src/main/java/fr/nc0/cda/nim/modele/EtatPartieNim.java
+++ b/src/main/java/fr/nc0/cda/nim/modele/EtatPartieNim.java
@@ -9,7 +9,7 @@ package fr.nc0.cda.nim.modele;
 /** Représente l'état d'une partie du jeu de Nim. */
 public enum EtatPartieNim {
   /** La partie est en cours. */
-  EnCours,
+  EN_COURS,
   /** La partie est finie. */
-  Fini
+  FINI
 }

--- a/src/main/java/fr/nc0/cda/nim/modele/Joueur.java
+++ b/src/main/java/fr/nc0/cda/nim/modele/Joueur.java
@@ -6,24 +6,30 @@
 
 package fr.nc0.cda.nim.modele;
 
+/** Représente une partie d'un jeu. */
 public class Joueur {
-
+  /** Le nom du joueur. */
   private final String nom;
-  private int nbrPartieGagnee;
 
+  /** Le nombre de parties gagnées par le joueur. */
+  private int nbrPartieGagnee = 0;
+
+  /** Créer un joueur avec un nom donné. */
   public Joueur(String nom) {
     this.nom = nom;
-    nbrPartieGagnee = 0;
   }
 
+  /** Récupère le nom du joueur. */
   public String getNom() {
     return nom;
   }
 
+  /** Récupère le nombre de parties gagnées par le joueur. */
   public int getNbrPartieGagnee() {
     return nbrPartieGagnee;
   }
 
+  /** Ajoute une partie gagnée au joueur. */
   public void ajouterPartieGagnee() {
     nbrPartieGagnee++;
   }

--- a/src/main/java/fr/nc0/cda/nim/modele/Nim.java
+++ b/src/main/java/fr/nc0/cda/nim/modele/Nim.java
@@ -8,13 +8,27 @@ package fr.nc0.cda.nim.modele;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
+/** Représente une partie du jeu de Nim. */
 public class Nim {
-
+  /** Nombre de tas de la partie. */
   private final int nbrTas;
-  private ArrayList<Integer> tas;
-  private EtatPartie etatPartie;
 
+  /**
+   * Liste des tas de la partie, sous forme d'une liste. L'élément i de cette liste correspond au
+   * nombre d'allumettes dans le tas i.
+   */
+  private List<Integer> tas;
+
+  /** État de la partie. */
+  private EtatPartieNim etatPartie;
+
+  /**
+   * Créer une partie et l'initialise avec le nombre de tas donné.
+   *
+   * @param nbrTas le nombre de tas de la partie.
+   */
   public Nim(int nbrTas) {
     if (nbrTas >= 1) {
       this.nbrTas = nbrTas;
@@ -23,22 +37,34 @@ public class Nim {
     }
   }
 
+  /** Initialise les tas de la partie avec le nombre d'allumettes correspondant. */
   private void setupTas() {
-    tas = new ArrayList<Integer>(nbrTas);
-    for (int i = 1; i <= nbrTas; ++i) {
-      tas.add(2 * i - 1);
-    }
+    tas = new ArrayList<>(nbrTas);
+    for (int i = 1; i <= nbrTas; ++i) tas.add(2 * i - 1);
   }
 
+  /** Démarre la partie en initialisant les tas et en passant l'état de la partie à EnCours. */
   public void demarrerPartie() {
     setupTas();
-    etatPartie = EtatPartie.EnCours;
+    etatPartie = EtatPartieNim.EnCours;
   }
 
-  public ArrayList<Integer> getTas() {
+  /**
+   * Récupère la liste des tas de la partie.
+   *
+   * @return la liste des tas de la partie.
+   */
+  public List<Integer> getTas() {
     return tas;
   }
 
+  /**
+   * Supprime un nombre donné d'allumettes dans un tas donné.
+   *
+   * @param choix un tableau de deux entiers, le premier correspondant à l'index du tas et le second
+   *     au nombre d'allumettes à supprimer.
+   * @throws IllegalArgumentException si le choix est invalide.
+   */
   public void supprAllumettes(int[] choix) {
     try {
       verifierChoix(choix);
@@ -48,6 +74,11 @@ public class Nim {
     }
   }
 
+  /**
+   * Vérifie si le choix est valide.
+   *
+   * @param choix un tableau de deux entiers, le premier correspondant à l'index du tas et le second
+   */
   private void verifierChoix(int[] choix) {
     if (tas.size() <= choix[0] || choix[0] < 0) {
       throw new IllegalArgumentException("Valeur du tas incorrect");
@@ -58,10 +89,18 @@ public class Nim {
     }
   }
 
-  public EtatPartie getEtatPartie() {
+  /**
+   * Récupère l'état de la partie.
+   *
+   * @return l'état de la partie.
+   */
+  public EtatPartieNim getEtatPartie() {
     return etatPartie;
   }
 
+  /**
+   * Vérifie si la partie est finie. Si tous les tas sont vides, l'état de la partie est mis à Fini.
+   */
   public void checkEtatPartie() {
     boolean estFini = true;
     Iterator<Integer> it = tas.iterator();
@@ -72,12 +111,7 @@ public class Nim {
     }
 
     if (estFini) {
-      etatPartie = EtatPartie.Fini;
+      etatPartie = EtatPartieNim.Fini;
     }
-  }
-
-  public enum EtatPartie {
-    EnCours,
-    Fini
   }
 }

--- a/src/main/java/fr/nc0/cda/nim/modele/Nim.java
+++ b/src/main/java/fr/nc0/cda/nim/modele/Nim.java
@@ -46,7 +46,7 @@ public class Nim {
   /** Démarre la partie en initialisant les tas et en passant l'état de la partie à EnCours. */
   public void demarrerPartie() {
     setupTas();
-    etatPartie = EtatPartieNim.EnCours;
+    etatPartie = EtatPartieNim.EN_COURS;
   }
 
   /**
@@ -111,7 +111,7 @@ public class Nim {
     }
 
     if (estFini) {
-      etatPartie = EtatPartieNim.Fini;
+      etatPartie = EtatPartieNim.FINI;
     }
   }
 }

--- a/src/main/java/fr/nc0/cda/nim/vue/Ihm.java
+++ b/src/main/java/fr/nc0/cda/nim/vue/Ihm.java
@@ -6,16 +6,15 @@
 
 package fr.nc0.cda.nim.vue;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Scanner;
 
+/** Interface de relation entre l'utilisateur et le système. */
 public class Ihm {
-
   // !!!!! accepte les int suivant (input : 5  56 9 7) mais ne les traites pas
   // Pour tout les scanner voir delimiter pattern
 
   public int selectNbrTas() {
-
     boolean tasNotDone = true;
     int nbrTas = 0;
 
@@ -34,13 +33,24 @@ public class Ihm {
     return nbrTas;
   }
 
+  /**
+   * Demande le nom du joueur
+   *
+   * @param numeroJoueur numéro du joueur
+   * @return le nom du joueur
+   */
   public String selectNomJoueur(int numeroJoueur) {
     Scanner scanner = new Scanner(System.in);
     System.out.print("Veuillez saisir le nom du joueur " + numeroJoueur + " : ");
     return scanner.next();
   }
 
-  public void afficherEtatPartie(ArrayList<Integer> tas) {
+  /**
+   * Affiche l'état de la partie
+   *
+   * @param tas liste des tas
+   */
+  public void afficherEtatPartie(List<Integer> tas) {
     String affichage = "";
     for (int i = 0; i < tas.size(); ++i) {
       affichage = affichage + "Tas " + (i + 1) + " : ";
@@ -50,6 +60,13 @@ public class Ihm {
     System.out.println("Etat de la partie : \n\n" + affichage);
   }
 
+  /**
+   * Affiche un pattern
+   *
+   * @param pattern le pattern
+   * @param nbr le nombre de fois que le pattern doit être affiché
+   * @return le pattern affiché
+   */
   private String patternAffichage(String pattern, int nbr) {
     if (nbr > 0) {
       return pattern + patternAffichage(pattern, nbr - 1);
@@ -58,6 +75,12 @@ public class Ihm {
     }
   }
 
+  /**
+   * Demande au joueur de choisir un tas et un nombre d'allumette
+   *
+   * @param joueurNom nom du joueur
+   * @return un tableau contenant le tas et le nombre d'allumette
+   */
   public int[] selectAlumette(String joueurNom) {
     Scanner scanner = new Scanner(System.in);
     boolean enCours = true;

--- a/src/main/java/fr/nc0/cda/puissance4/modele/Joueur.java
+++ b/src/main/java/fr/nc0/cda/puissance4/modele/Joueur.java
@@ -6,23 +6,30 @@
 
 package fr.nc0.cda.puissance4.modele;
 
+/** Représente une partie d'un jeu. */
 public class Joueur {
+  /** Le nom du joueur. */
   private final String nom;
-  private int nbrPartieGagnee;
 
+  /** Le nombre de parties gagnées par le joueur. */
+  private int nbrPartieGagnee = 0;
+
+  /** Créer un joueur avec un nom donné. */
   public Joueur(String nom) {
     this.nom = nom;
-    nbrPartieGagnee = 0;
   }
 
+  /** Récupère le nom du joueur. */
   public String getNom() {
     return nom;
   }
 
+  /** Récupère le nombre de parties gagnées par le joueur. */
   public int getNbrPartieGagnee() {
     return nbrPartieGagnee;
   }
 
+  /** Ajoute une partie gagnée au joueur. */
   public void ajouterPartieGagnee() {
     nbrPartieGagnee++;
   }


### PR DESCRIPTION
Cette branche propose des changements de code de la logique du jeu de Nim d'un point de vue uniquement stylistique (respect avec le Google Java Style Guide) et compliance avec notre CI défini dans `//.github/workflows/*`.

Le changement notoire du code effectué dans ce patch est la transition de l'énumération `Nim.EtatPartie` dans son propre fichier public `//src/main/java/fr/nc0/cda/nim/modele/EtatPartieNim.java` et donc le changement du nom de l'énumération de `EtatPartie` en `EtatPartieNim` (pour éviter les futurs problèmes de fusion lorsque nous passerons à l'itération 3).

Sinon, il s'agît simplement de lint, reformat, et d'ajouter des commentaires ainsi que de la JavaDoc aux fonctions et classes.